### PR TITLE
Add test for OPVault reading and CI workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,18 @@
+name: Go Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.20'
+
+    - name: Run tests
+      run: go test ./...

--- a/vault_test.go
+++ b/vault_test.go
@@ -1,0 +1,39 @@
+package opvault
+
+import (
+	"testing"
+)
+
+func TestReadOpvault(t *testing.T) {
+	vault, err := Open("testdata/onepassword_data")
+	if err != nil {
+		t.Fatalf("Failed to open vault: %v", err)
+	}
+
+	profile, err := vault.Profile("default")
+	if err != nil {
+		t.Fatalf("Failed to get profile: %v", err)
+	}
+
+	if profile == nil {
+		t.Fatal("Profile is nil before unlock")
+	}
+
+	// Unlock the profile with the password
+	err = profile.Unlock("freddy")
+	if err != nil {
+		t.Fatalf("Failed to unlock profile: %v", err)
+	}
+
+	// Assert that the profile object is not nil after unlock
+	// (though Unlock doesn't return a new profile, we ensure it's still valid)
+	if profile == nil {
+		t.Fatal("Profile is nil after unlock")
+	}
+
+	// Additional check: try to read something that requires unlocking
+	_, err = profile.Items()
+	if err != nil {
+		t.Fatalf("Failed to get items after unlock: %v", err)
+	}
+}


### PR DESCRIPTION
This commit introduces:
1. A new test case (`TestReadOpvault` in `vault_test.go`) that verifies the ability to open an OPVault, unlock a profile using a master password, and retrieve items. The test uses data from `testdata/onepassword_data` with the password "freddy".

2. A GitHub Actions workflow (`.github/workflows/go-test.yml`) that automatically runs `go test ./...` on every push to the repository. This ensures that the tests are executed continuously.